### PR TITLE
retry get content length on failure

### DIFF
--- a/public/codal-wasm/modules/FileSystem.mjs
+++ b/public/codal-wasm/modules/FileSystem.mjs
@@ -81,7 +81,7 @@ export default class FileSystem extends EmProcess {
     //https://javascript.info/fetch-progress
     async getContent(response, onProgress = (progress)=>{}) {
         const contentLengthHeader = response.headers.get('Content-Length')
-        const contentLength = +contentLengthHeader;
+        let contentLength = +contentLengthHeader;
 
         const reader = response.body.getReader();
 
@@ -91,6 +91,14 @@ export default class FileSystem extends EmProcess {
         let receivedLength = 0; // received that many bytes at the moment
         let chunks = []; // array of received binary chunks (comprises the body)
         while(true) {
+            if(contentLength === 0) {
+                //retry get content length
+                console.log("retry get content length")
+                const lengthHeader = response.headers.get('Content-Length')
+                contentLength = +lengthHeader;
+                console.log(`Download Size: ${contentLength}`);
+            }
+
             const {done, value} = await reader.read();
 
             if (done) {


### PR DESCRIPTION
sometimes content length header is not read which causes loading bar to incorrectly display download progress. This was previously caught, but not addressed.

Now each time data is read from the fetch response, the header is attempted to be read again if the content length is 0.